### PR TITLE
Удалять неиспользуемые образы после деплоя + удалять файл с ключами с worker машинки

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -78,3 +78,11 @@ jobs:
           DOCKER_TAG=dev docker compose -p samowarium-dev down samowarium && 
           DOCKER_TAG=dev docker compose -p samowarium-dev up -d samowarium ||
           exit 1
+
+    - name: Prune images
+      run: |
+          docker image prune -f
+
+    - name: Remove configuration files
+      run: |
+          rm ./.env

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -95,6 +95,14 @@ jobs:
             DOCKER_TAG=latest docker compose -p samowarium-dev up -d samowarium ||
             exit 1
 
+      - name: Prune images
+        run: |
+            docker image prune -f
+
+      - name: Remove configuration files
+        run: |
+            rm ./.env
+
   deploy-to-prod:
     needs: [build-and-push-image, deploy-to-dev]
     if: |
@@ -139,3 +147,11 @@ jobs:
             DOCKER_TAG=latest docker compose -p samowarium-prod down samowarium && 
             DOCKER_TAG=latest docker compose -p samowarium-prod up -d samowarium ||
             exit 1
+
+      - name: Prune images
+        run: |
+            docker image prune -f
+
+      - name: Remove configuration files
+        run: |
+            rm ./.env


### PR DESCRIPTION
После выполнения деплоя остаются неиспользованные образы, которые занимают место + на worker тачке остается .env файл с чувствительным данными. Этот пулрик исправляет данные недочеты.