### PR TITLE
Potential fix for code scanning alert no. 14: Clear-text logging of sensitive information

### DIFF
--- a/src/telegram_bot.py
+++ b/src/telegram_bot.py
@@ -246,7 +246,7 @@ class TelegramBot:
         attachments: Optional[list[tuple[bytes, str]]] = None,
     ) -> None:
         is_sent = False
-        log.debug(f'sending a message to {telegram_id} ...')
+        log.debug(f"sending a message to {telegram_id} ...")
         metrics.sent_message_metric.inc()
         while not is_sent:
             try:

--- a/src/telegram_bot.py
+++ b/src/telegram_bot.py
@@ -246,7 +246,7 @@ class TelegramBot:
         attachments: Optional[list[tuple[bytes, str]]] = None,
     ) -> None:
         is_sent = False
-        log.debug(f'sending message "{message}" to {telegram_id} ...')
+        log.debug(f'sending a message to {telegram_id} ...')
         metrics.sent_message_metric.inc()
         while not is_sent:
             try:


### PR DESCRIPTION
Potential fix for [https://github.com/bmstudents/samowarium/security/code-scanning/14](https://github.com/bmstudents/samowarium/security/code-scanning/14)

To fix the problem, we should avoid logging the entire message content when it might contain sensitive information. Instead, we can log a generic message indicating that a message is being sent without including the actual content. This way, we maintain the functionality of logging the action without exposing sensitive data.

- Modify the log statement on line 249 to exclude the `message` content.
- Ensure that the log still provides useful information by including the `telegram_id`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
